### PR TITLE
Fix #5 with nullable url parameter

### DIFF
--- a/src/DependencyInjection/ContaoModalExtension.php
+++ b/src/DependencyInjection/ContaoModalExtension.php
@@ -39,7 +39,7 @@ class ContaoModalExtension extends Extension
             $loader->load('listener.yaml');
         } catch (\Exception $e) {
             echo $e->getMessage();
-            exit();
+            exit;
         }
     }
 }

--- a/src/Modal/Builder.php
+++ b/src/Modal/Builder.php
@@ -192,10 +192,16 @@ class Builder
         return \in_array($page->id, $excludedPages, true);
     }
 
-    private function isModalPage(?PageModel $page, string $url): bool
+    /**
+     * @param PageModel|null $page
+     * @param string|null    $url
+     *
+     * @return bool
+     */
+    private function isModalPage(?PageModel $page, ?string $url): bool
     {
         // Check if an url is given
-        if ('' === $url) {
+        if (!$url) {
             return false;
         }
 


### PR DESCRIPTION
Fixing #5 
When using type `HTML` for the modal content, there is no url parameter withing the configuration. So it must be nullable.